### PR TITLE
new feature

### DIFF
--- a/Selenium_Demo/SeleniumLearning.cs
+++ b/Selenium_Demo/SeleniumLearning.cs
@@ -58,6 +58,7 @@ namespace Selenium_Learning
             Assert.IsTrue(txtSrch2.GetAttribute("value") == "India", "Search keyword not matching");
             Assert.IsTrue(txtSrch2.GetAttribute("maxlength") == "2048", "maxlength not matching");
             Console.WriteLine(txtSrch2.GetAttribute("name"));
+            Console.WriteLine(txtSrch2.GetAttribute("type"));
         }
         [Test]
         public void InteractWithCheckBoxAndRadio()

--- a/Selenium_Demo/SeleniumLearning.cs
+++ b/Selenium_Demo/SeleniumLearning.cs
@@ -991,6 +991,7 @@ namespace Selenium_Learning
             dr.Manage().Cookies.AddCookie(co3);
 
             dr.Manage().Cookies.DeleteCookieNamed("course");
+            //dr.Manage().Cookies.DeleteCookie(co1);
             //dr.Manage().Cookies.DeleteAllCookies();
 
             ICookieJar listCookies = dr.Manage().Cookies;


### PR DESCRIPTION
Enhance debugging for search input field

Added a line to print the "type" attribute of the `txtSrch2` web element to improve debugging information when interacting with the search input field.

Enhance debugging output for search input element

Added a line to print the "type" attribute of the
`txtSrch2` web element in the `SeleniumLearning.cs` file to improve debugging information.