### PR TITLE
Remove letter count display from ReadExcel.cs

### DIFF
--- a/Selenium_Demo/ReadExcel.cs
+++ b/Selenium_Demo/ReadExcel.cs
@@ -190,11 +190,9 @@ namespace Selenium_Demo
 
             }
             foreach (var item in LetterCount)
-
             {
                 Console.WriteLine($"Letter : {item.Key}, Count : {item.Value}");
             }
-
         }
         [Test]
         public void Letter()


### PR DESCRIPTION
Eliminated the `foreach` loop that outputs letter counts to the console in the `Selenium_Demo` namespace.